### PR TITLE
Media Query Mixins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Manhattan](http://kohactive.github.io/manhattan/)
 
-Manhattan is a powerful, mobile-first responsive framework built on top of Bourbon Neat. It's similar to Bootstrap 3 in syntax and usage but approachs the grid system differently.
+Manhattan is a powerful, mobile-first responsive framework built on top of Bourbon Neat. It's similar to Bootstrap 3 in syntax and usage but approaches the grid system differently.
 
 ## Usage
 

--- a/app/assets/stylesheets/manhattan/_mixins.sass
+++ b/app/assets/stylesheets/manhattan/_mixins.sass
@@ -4,7 +4,7 @@
 // Create the grid for a given size
 // This will loop over the number of columns and create a css class
 // for each. If it's the last gride size, then let's not add a float
-@mixin grid-core($size)
+=grid-core($size)
   @for $i from 1 through $grid-columns
     .col-#{$size}-#{$i}
       @include span-columns($i)
@@ -36,7 +36,7 @@
 
 
 // Omega Core builder
-@mixin omega-core($size)
+=omega-core($size)
   @for $i from 1 through $grid-columns
     .omega-#{$size}-#{$i}
       > [class^="col-"],
@@ -47,7 +47,7 @@
 // Thoughtbot doesn't want to add a gutterless display type for 
 // span columns so we'll use this mixin for now. This will create
 // equal column widths without any margin/gutters
-@mixin span-columns-gutterless($span: $columns of $container-columns) 
+=span-columns-gutterless($span: $columns of $container-columns) 
   $columns: nth($span, 1)
   $container-columns: container-span($span)
 
@@ -61,3 +61,33 @@
      
   &:last-child
     width: percentage($columns / $container-columns)
+
+
+// Responsive mixins
+=media-xs
+  @media screen and (max-width: $screen-sm - 1)
+    @content
+
+=media-sm
+  @media screen and (min-width: $screen-sm)
+    @content
+
+=media-xs-sm
+  +media(max-width $screen-md - 1)
+    @content
+
+=media-sm-only
+  +media(min-width $screen-sm max-width $screen-md - 1)
+    @content
+
+=media-sm-md-only
+  +media(min-width $screen-sm max-width $screen-lg - 1)
+    @content
+
+=media-md
+  @media screen and (min-width: $screen-md)
+    @content
+
+=media-lg
+  @media screen and (min-width: $screen-lg)
+    @content

--- a/app/assets/stylesheets/manhattan/_variables.sass
+++ b/app/assets/stylesheets/manhattan/_variables.sass
@@ -2,41 +2,41 @@
 // --------------------------------------------------
 
 // Number of columns in the grid system
-$grids-columns:              12 !default
+$grids-columns:              12
 // Padding, to be divided by two and applied to the left and right of all columns
-$gutter:                     golden-ratio(1em, 1) !default
+$gutter:                     golden-ratio(1em, 1)
 
-$max-width:                  1200px !default
+$max-width:                  1200px
 
-$col-padding:                10px !default
+$col-padding:                10px
 
 // Turn responsive on or off
-$responsive:                 true !default
+$responsive:                 true
 
 // Responsive Breakpoints
 // ------------------------------------------------------
 
-$screen-xs:                  480px !default
-$screen-xs-min:              $screen-xs !default
-$screen-phone:               $screen-xs-min !default
+$screen-xs:                  480px
+$screen-xs-min:              $screen-xs
+$screen-phone:               $screen-xs-min
 
 // Small screen / tablet
-$screen-sm:                  768px !default
-$screen-sm-min:              $screen-sm !default
-$screen-tablet:              $screen-sm-min !default
+$screen-sm:                  768px
+$screen-sm-min:              $screen-sm
+$screen-tablet:              $screen-sm-min
 
 // Medium screen / desktop
-$screen-md:                  992px !default
-$screen-md-min:              $screen-md !default
-$screen-desktop:             $screen-md-min !default
+$screen-md:                  992px
+$screen-md-min:              $screen-md
+$screen-desktop:             $screen-md-min
 
 // Large screen / wide desktop
-$screen-lg:                  1200px !default
-$screen-lg-min:              $screen-lg !default
-$screen-lg-desktop:          $screen-lg-min !default
-$max-width:                  $screen-lg !default
+$screen-lg:                  1200px
+$screen-lg-min:              $screen-lg
+$screen-lg-desktop:          $screen-lg-min
+$max-width:                  $screen-lg
 
 // So media queries don't overlap when required, provide a maximum
-$screen-xs-max:              ($screen-sm-min - 1) !default
-$screen-sm-max:              ($screen-md-min - 1) !default
-$screen-md-max:              ($screen-lg-min - 1) !default
+$screen-xs-max:              ($screen-sm-min - 1)
+$screen-sm-max:              ($screen-md-min - 1)
+$screen-md-max:              ($screen-lg-min - 1)


### PR DESCRIPTION
@lrdiv: PTAL: these have been manually added to every project I've worked on since they were written...over a year ago. The reason they belong in this project is their relation to the breakpoint variables that are set in manhattan.

I also switched the other mixins in this file to use the `=` syntax rather than `@mixin` for conformity.

Also also, I removed the `!defaults` from the variables since they were used for an unintended purpose that is rendering them useless: https://robots.thoughtbot.com/sass-default

* closes #10 