### PR TITLE
Omega & Vars Fixes

### DIFF
--- a/app/assets/stylesheets/manhattan/_mixins.sass
+++ b/app/assets/stylesheets/manhattan/_mixins.sass
@@ -43,6 +43,9 @@
       > [class*=" col-"]
         @include omega("#{$i}n")
 
+        &:nth-child(#{$i}n+1)
+          clear: left
+
 
 // Thoughtbot doesn't want to add a gutterless display type for 
 // span columns so we'll use this mixin for now. This will create

--- a/app/assets/stylesheets/manhattan/_variables.sass
+++ b/app/assets/stylesheets/manhattan/_variables.sass
@@ -1,37 +1,30 @@
 // Grid system
 // --------------------------------------------------
 
-// Number of columns in the grid system
-$grids-columns:              12
-// Padding, to be divided by two and applied to the left and right of all columns
-$gutter:                     golden-ratio(1em, 1)
-
-$max-width:                  1200px
-
-$col-padding:                10px
+$col-padding:                0 !default
 
 // Turn responsive on or off
-$responsive:                 true
+$responsive:                 true !default
 
 // Responsive Breakpoints
 // ------------------------------------------------------
 
-$screen-xs:                  480px
+$screen-xs:                  480px !default
 $screen-xs-min:              $screen-xs
 $screen-phone:               $screen-xs-min
 
 // Small screen / tablet
-$screen-sm:                  768px
+$screen-sm:                  768px !default
 $screen-sm-min:              $screen-sm
 $screen-tablet:              $screen-sm-min
 
 // Medium screen / desktop
-$screen-md:                  992px
+$screen-md:                  992px !default
 $screen-md-min:              $screen-md
 $screen-desktop:             $screen-md-min
 
 // Large screen / wide desktop
-$screen-lg:                  1200px
+$screen-lg:                  1200px !default
 $screen-lg-min:              $screen-lg
 $screen-lg-desktop:          $screen-lg-min
 $max-width:                  $screen-lg

--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "kohactive <info@kohactive.com>"
   ],
   "description": "A powerful, mobile-first responsive framework built on Bourbon Neat.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "",
   "moduleType": [],
   "keywords": [

--- a/lib/manhattan/version.rb
+++ b/lib/manhattan/version.rb
@@ -1,3 +1,3 @@
 module Manhattan
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end


### PR DESCRIPTION
@lrdiv, @maria-faulisi: mind taking a look at this before I merge it?
- omega mixin correctly clears (fixes #4)
- variables fix (fixes #16)
  - max-width, grid-columns, & gutter no longer need to be set in Manhattan
  - defaulting col-padding to 0
